### PR TITLE
Fix typo in InternalStack Init predicate

### DIFF
--- a/posts/tlaplus_part4.html
+++ b/posts/tlaplus_part4.html
@@ -574,7 +574,7 @@
 \\
 &&\rlap{NOTHING \defeq \CHOOSE x : x \notin X} \\
 \\
-&& Init &\defeq buf \in \seq{} \land in = NOTHING \land out = NOTHING\\
+&& Init &\defeq buf = \seq{} \land in = NOTHING \land out = NOTHING\\
 &&Push &\defeq in' \in X \land buf' = \seq{in'} \circ buf \land \UNCHANGED out\\
 &&Pop &\defeq buf \neq \seq{} \land out' = Head(buf) \land buf' = Tail(buf) \land \UNCHANGED in\\
 &&Top &\defeq buf \neq \seq{} \land out' = Head(buf)\land \UNCHANGED \seq{in, buf}\\


### PR DESCRIPTION
In the Init predicate for InternalStack, it looks like buf should be equal to the empty sequence rather than an element of it.